### PR TITLE
More robust title regex

### DIFF
--- a/dot.irssi/scripts/irssi-rss.pl
+++ b/dot.irssi/scripts/irssi-rss.pl
@@ -44,7 +44,7 @@ sub _parse_rss {
 				while ($xml =~ /<(?:entry|item)[^>]*>(.*?)<\/(?:entry|item)>/isg) {
 					my $item = $1;
 					my ($link, $title);
-					if ($item =~ /<title>(.*?)<\/title>/i) {
+					if ($item =~ /<title[^>]*>(.*?)<\/title>/i) {
 						$title = $1;
 						$title =~ s/&#(x[0-9a-fA-F]+|[0-9]+);/chr($1)/eg;
 						while ($title =~ /&amp;/i) { $title =~ s/&amp;/\&/gi }


### PR DESCRIPTION
I've found that many feeds include a `type`-attribute in the `title`-tag so that it looks for example like

```
<title type="text">Title of the entry</title>
```

and since the regex searches for only `<title>` and demands an entry have a title no entries would be parsed.

This is a small fix to make the regex more robust. Hope you find this usefull!
